### PR TITLE
update setup github url arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     long_description=open('README.md').read(),
     author='TabbedOut',
     author_email='dev@tabbedout.com',
-    url='https://github.com/TabbedOut/django-canary-endpoint',
+    url='https://github.com/TabbedOut/django_canary_endpoint',
     license='MIT License',
     packages=find_packages(exclude=('tests', 'docs')),
     test_suite='tests',


### PR DESCRIPTION
s/django-canary-endpoint/django_canary_endpoint/

A tiny change but otherwise the link from PyPI to the repository is broken...

Thanks for sharing your code!